### PR TITLE
ci(release): keep release pull requests verifiable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -36,6 +36,13 @@ Pre-releases use `alpha`, `beta`, and `rc`, for example `0.5.0-alpha.1`.
 5. Attach a repository bundle and `SHA256SUMS.txt`.
 6. Verify tag, release notes, assets, and checksums from GitHub.
 
+For fully automatic validation of Release Please pull requests, configure the
+repository secret `RELEASE_PLEASE_TOKEN` with a narrowly scoped fine-grained token
+or GitHub App token that can write contents, pull requests, and issues. Pull requests
+created with the fallback `GITHUB_TOKEN` may not trigger another workflow run. In
+that case, a maintainer must run the `CI` workflow manually against the release
+branch before merge; the required quality gate is never bypassed.
+
 The initial `v0.1.0` release is a technical-preview baseline. `version.txt`, the
 Python `__version__`, the release manifest, tag, and GitHub Release must agree.
 


### PR DESCRIPTION
Prevents future Release Please pull requests from being blocked by the protected main branch when GitHub suppresses workflow events created by the default GITHUB_TOKEN.

- uses a narrowly scoped RELEASE_PLEASE_TOKEN when configured
- retains github.token as a fallback
- enables manual CI dispatch against a release branch
- documents the non-bypass fallback procedure

Local verification: 53 unit/package tests, 25 Draw.io QA tests, and skill validation passed.