### PR TITLE
ci(release): normalize GitHub release titles

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,13 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Normalize GitHub release title
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        run: gh release edit "$RELEASE_TAG" --title "NexCanvas $RELEASE_TAG"
+
       - name: Check out released tag
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v6

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -26,6 +26,12 @@ clear release notes and migration support for persisted user projects.
 
 Pre-releases use `alpha`, `beta`, and `rc`, for example `0.5.0-alpha.1`.
 
+Every GitHub Release title uses `NexCanvas <tag>`, for example
+`NexCanvas v0.5.0` or `NexCanvas v0.5.0-rc.1`. Maturity belongs in GitHub's
+pre-release flag and the release notes, not in an ad hoc title suffix. Release
+automation normalizes this title after creating a release so the sidebar stays
+compact and consistent across versions.
+
 ## Release process
 
 1. Merge conventional feature and fix pull requests into an always-releasable

--- a/scripts/validate_skill.py
+++ b/scripts/validate_skill.py
@@ -79,6 +79,7 @@ def validate() -> list[str]:
         "version.txt",
         "release-please-config.json",
         ".release-please-manifest.json",
+        ".github/workflows/release-please.yml",
     ]
     for relative in required:
         if not (ROOT / relative).is_file():
@@ -113,6 +114,16 @@ def validate() -> list[str]:
         }
         if len(set(versions.values())) != 1:
             issues.append(f"product versions do not match: {versions}")
+
+    release_workflow_path = ROOT / ".github" / "workflows" / "release-please.yml"
+    if release_workflow_path.is_file():
+        release_workflow = release_workflow_path.read_text(encoding="utf-8")
+        title_command = 'gh release edit "$RELEASE_TAG" --title "NexCanvas $RELEASE_TAG"'
+        if title_command not in release_workflow:
+            issues.append(
+                ".github/workflows/release-please.yml: missing canonical "
+                "NexCanvas release-title normalization"
+            )
 
     for relative in [
         "SKILL.md",


### PR DESCRIPTION
Standardizes every GitHub Release title as `NexCanvas <tag>`, documents the convention, and makes the repository validator reject release workflows that omit title normalization.\n\nValidation:\n- 75 unit tests\n- repository skill validator\n- workflow YAML parse\n- existing seven releases normalized and verified