### PR TITLE
docs(conformance): define evidence-based host contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -354,6 +354,12 @@ and compatible Agent Skills hosts.
 
 Target release: `v0.6.0`.
 
+Accepted scope: one shared `SKILL.md` and CLI core; data-only host adapters;
+versioned, provider-neutral corpus cases; deterministic artifact scoring across
+five independent dimensions; and a capability matrix that distinguishes
+`verified`, `not-run`, `unavailable`, and `failed`. Fixture runs may test the
+evaluator but may not establish host support. See ADR 0009.
+
 ## Phase 7 - extension ecosystem and visual benchmarks
 
 Objective: let contributors extend the project without editing compiler internals.

--- a/docs/adr/0009-cross-agent-conformance.md
+++ b/docs/adr/0009-cross-agent-conformance.md
@@ -1,0 +1,53 @@
+# ADR 0009: Evidence-based cross-agent conformance
+
+- Status: accepted
+- Date: 2026-09-10
+
+## Context
+
+NexCanvas is installed through different discovery paths in Codex, GitHub
+Copilot, Claude Code, and other Agent Skills hosts. The hosts may interpret the
+same natural-language instructions differently, expose different tools, or stop
+at different workflow stages. Prompt similarity and a visually plausible image
+therefore do not demonstrate equivalent behavior.
+
+Duplicating the complete workflow for every host would create several sources of
+truth. Those copies would drift independently and make a passing host adapter
+meaningless when the shared skill changes.
+
+## Decision
+
+NexCanvas uses one shared skill and deterministic CLI core. A host adapter is a
+small data contract that records only discovery paths, runtime detection,
+invocation guidance, evidence requirements, and known limitations. It must not
+duplicate the drawing workflow.
+
+Cross-agent conformance is measured against versioned corpus cases and observable
+project artifacts. Each result reports five independent dimensions:
+
+1. semantic coverage;
+2. evidence and provenance;
+3. asset resolution;
+4. route and layout planning;
+5. delivery-gate completion.
+
+The conformance scorer is deterministic. It evaluates a completed project and
+does not award credit for prose claims in an agent transcript. Fixture results
+exercise the scorer but can never establish host support.
+
+A host may be reported as `verified` only when an observed run includes the host
+identity, adapter version, skill digest, corpus-case digest, timestamps, execution
+evidence, and the evaluated project artifact digests. Other explicit states are
+`not-run`, `unavailable`, and `failed`.
+
+## Consequences
+
+- Host behavior can be compared without requiring byte-identical diagrams.
+- Semantic and delivery regressions are visible by dimension.
+- CI can validate the corpus, adapters, schemas, scorer, and fixtures without
+  pretending to execute proprietary hosts.
+- Real host verification remains an external integration test and must be
+  refreshed when the skill, adapter, or corpus digest changes.
+- A published capability matrix can contain unavailable or not-run hosts; those
+  entries are limitations, not passing evidence.
+

--- a/docs/public-contracts.md
+++ b/docs/public-contracts.md
@@ -16,6 +16,8 @@ The following are public contracts:
 - the standard generated-project directory layout;
 - stable semantic IDs and semantics-only fingerprints in diagram model V3;
 - repository snapshot `1.0` and semantic sync-plan `1.0`;
+- conformance suite `1.0`, host adapter `1.0`, execution record `1.0`, and
+  conformance result `1.0`;
 - extension manifests and plugin interfaces once published;
 - the delivery definition for editable, rendered, and verified artifacts.
 
@@ -63,3 +65,8 @@ Host-specific skill discovery and permissions are separate from the diagram
 contract. A host is supported only when its documented installation is tested and
 its capability limitations are published. Prompt similarity alone is not evidence
 of cross-agent conformance.
+
+Conformance fixtures validate the deterministic evaluator only. A host is marked
+`verified` only from an observed run whose execution record binds the host,
+adapter, skill, corpus case, project artifacts, and timestamps by digest. Results
+become stale when any of those versioned inputs changes.


### PR DESCRIPTION
## Summary
- establish one shared skill with thin host adapters
- define observed versus fixture conformance evidence
- document the five scored dimensions and truthful host states

## Validation
- python scripts/validate_skill.py
- git diff --check