### PR TITLE
feat(conformance): add evidence-based host evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,23 @@ jobs:
       - run: python scripts/nexcanvas_cli.py postflight examples/v4-hub-spoke-industrial
       - run: python scripts/nexcanvas_cli.py postflight examples/v5-multi-agent-workflow
 
+  conformance-validation:
+    name: Cross-agent conformance contracts and fixtures
+    env:
+      PYTHONPATH: ${{ github.workspace }}/src
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python scripts/validate_conformance.py
+      - run: python scripts/nexcanvas_cli.py conformance report --no-discovery
+
   quality-gate:
     name: Quality gate
     if: always()
-    needs: [core-tests, skill-validation, reference-validation]
+    needs: [core-tests, skill-validation, reference-validation, conformance-validation]
     runs-on: ubuntu-latest
     steps:
       - name: Require every validation job
@@ -87,6 +100,7 @@ jobs:
           CORE_RESULT: ${{ needs.core-tests.result }}
           SKILL_RESULT: ${{ needs.skill-validation.result }}
           REFERENCE_RESULT: ${{ needs.reference-validation.result }}
+          CONFORMANCE_RESULT: ${{ needs.conformance-validation.result }}
         run: |
           python - <<'PY'
           import os
@@ -96,6 +110,7 @@ jobs:
               "core-tests": os.environ["CORE_RESULT"],
               "skill-validation": os.environ["SKILL_RESULT"],
               "reference-validation": os.environ["REFERENCE_RESULT"],
+              "conformance-validation": os.environ["CONFORMANCE_RESULT"],
           }
           failed = {name: result for name, result in results.items() if result != "success"}
           if failed:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ python -m pip install -e .
 python -m unittest discover -s tests -v
 python scripts/test_drawio_qa.py -v
 python scripts/validate_skill.py
+python scripts/validate_conformance.py
 nexcanvas doctor
 python scripts/package_smoke.py
 ```

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ as a generic component inventory.
 | Native output | Produces inspectable, uncompressed mxGraph XML instead of pasting a bitmap onto a canvas |
 | Collision QA | Rejects node, icon, label, step-badge, connector-lane, and visible boundary-outline collisions |
 | Visual proof | Renders through Draw.io Desktop, requires human/agent image inspection, then seals hashes at postflight |
+| Cross-agent conformance | Uses one shared skill, hash-bound host run packs, five-dimensional scoring, and explicit verified/not-run/unavailable/failed states |
 
 ## Agent-guided intake
 
@@ -257,7 +258,7 @@ nexcanvas init docs/architecture --name "My architecture" --family software --pr
 ```
 
 `init` creates a canonical V3 diagram model. Existing V2 projects remain readable
-in `v0.5.x`, but incremental repository sync requires V3. To migrate without
+in `v0.6.x`, but incremental repository sync requires V3. To migrate without
 overwriting the original:
 
 ```bash
@@ -435,6 +436,7 @@ nexcanvas-output/                documented default generated-output root
 python -m pip install -e .
 python -m unittest discover -s tests -v
 python scripts/test_drawio_qa.py -v
+python scripts/validate_conformance.py
 nexcanvas doctor
 python scripts/package_smoke.py
 ```
@@ -445,6 +447,23 @@ GitHub Copilot, Claude Code, and other hosts that implement Agent Skills.
 
 The complete command surface, exit-code contract, installation behavior, and
 compatibility window are documented in the [CLI reference](docs/cli.md).
+
+## Cross-agent conformance
+
+NexCanvas does not call two prompts equivalent merely because their screenshots
+look similar. The Phase 6 harness evaluates semantic coverage, source evidence,
+assets, routing/layout decisions, and completed delivery gates against a versioned
+five-intent corpus. Fixture baselines test the evaluator and never verify a host.
+
+```bash
+nexcanvas conformance doctor
+nexcanvas conformance prepare multi-agent-workflow --host codex --output conformance-run
+nexcanvas conformance evaluate conformance-run/request.json --project conformance-run/project --mode observed --execution conformance-run/execution.json
+```
+
+Read the [method and trust model](docs/conformance.md), the
+[run workflow](workflows/conformance.md), and the current
+[host capability matrix](docs/host-capability-matrix.md).
 
 ## Project governance
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -347,10 +347,10 @@ release-candidate builds.
 Objective: measure consistent semantics and quality across Codex, Copilot, Claude,
 and compatible Agent Skills hosts.
 
-- [ ] Keep one shared core and thin host-specific adapters.
-- [ ] Build a representative conformance corpus.
+- [x] Keep one shared core and thin host-specific adapters.
+- [x] Build a representative conformance corpus.
 - [ ] Compare semantic coverage, evidence, assets, routing, and gate completion.
-- [ ] Publish a host capability and limitation matrix.
+- [x] Publish a host capability and limitation matrix.
 
 Target release: `v0.6.0`.
 
@@ -359,6 +359,13 @@ versioned, provider-neutral corpus cases; deterministic artifact scoring across
 five independent dimensions; and a capability matrix that distinguishes
 `verified`, `not-run`, `unavailable`, and `failed`. Fixture runs may test the
 evaluator but may not establish host support. See ADR 0009.
+
+Implementation checkpoint: the suite contains five semantic-intent cases and two
+tracked fixture baselines; four data-only host adapters share the root skill; the
+installed wheel carries the corpus, adapters, schemas, and skill digest input;
+and CI validates the scorer plus the rule that fixtures cannot verify a host.
+Observed corpus runs are still required before the comparison item and Phase 6
+can be marked complete.
 
 ## Phase 7 - extension ecosystem and visual benchmarks
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,6 +19,10 @@ Read exactly one primary workflow:
 - Repair, restyle, or extend an existing `.drawio`: [workflows/repair.md](workflows/repair.md)
 - Recreate a screenshot, slide, Mermaid/PlantUML result, or visual reference: [workflows/convert-reference.md](workflows/convert-reference.md)
 
+When measuring whether this skill behaves consistently in another agent host,
+read [workflows/conformance.md](workflows/conformance.md). Conformance is an
+evaluation workflow, not a substitute for one of the drawing workflows above.
+
 Always read:
 
 - [references/intake-and-discovery.md](references/intake-and-discovery.md)

--- a/conformance/hosts/claude-code.json
+++ b/conformance/hosts/claude-code.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "1.0",
+  "id": "claude-code",
+  "displayName": "Claude Code",
+  "sharedSkill": "SKILL.md",
+  "docsUrl": "https://code.claude.com/docs/en/slash-commands",
+  "discoveryPaths": [".claude/skills/nexcanvas-drawio"],
+  "executableNames": ["claude"],
+  "execution": "automated-cli",
+  "evidence": ["non-interactive command transcript", "completed NexCanvas project", "host version"],
+  "limitations": ["Tool permissions, model selection, and project trust settings affect execution."]
+}

--- a/conformance/hosts/codex.json
+++ b/conformance/hosts/codex.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "1.0",
+  "id": "codex",
+  "displayName": "OpenAI Codex",
+  "sharedSkill": "SKILL.md",
+  "docsUrl": "https://learn.chatgpt.com/docs/build-skills",
+  "discoveryPaths": [".agents/skills/nexcanvas-drawio", "$HOME/.agents/skills/nexcanvas-drawio", "$CODEX_HOME/skills/nexcanvas-drawio", "~/.codex/skills/nexcanvas-drawio"],
+  "executableNames": ["codex"],
+  "execution": "automated-cli",
+  "evidence": ["non-interactive command transcript", "completed NexCanvas project", "host version"],
+  "limitations": ["Tool availability and approval policy vary by Codex environment."]
+}

--- a/conformance/hosts/generic-agent-skills.json
+++ b/conformance/hosts/generic-agent-skills.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "1.0",
+  "id": "generic-agent-skills",
+  "displayName": "Compatible Agent Skills host",
+  "sharedSkill": "SKILL.md",
+  "docsUrl": "https://agentskills.io",
+  "discoveryPaths": ["host-defined skill directory"],
+  "executableNames": [],
+  "execution": "manual-export",
+  "evidence": ["host session transcript", "completed NexCanvas project", "host and adapter identity"],
+  "limitations": ["Discovery, invocation, and tool permissions are host-defined until a dedicated adapter is published."]
+}

--- a/conformance/hosts/github-copilot.json
+++ b/conformance/hosts/github-copilot.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "1.0",
+  "id": "github-copilot",
+  "displayName": "GitHub Copilot",
+  "sharedSkill": "SKILL.md",
+  "docsUrl": "https://docs.github.com/en/copilot/concepts/agents/about-agent-skills",
+  "discoveryPaths": [".github/skills/nexcanvas-drawio", ".agents/skills/nexcanvas-drawio"],
+  "executableNames": ["copilot"],
+  "execution": "manual-export",
+  "evidence": ["Copilot session transcript or task URL", "completed NexCanvas project", "host version or surface"],
+  "limitations": ["GitHub, IDE, coding-agent, and CLI surfaces can expose different tools and permissions."]
+}

--- a/conformance/suite.json
+++ b/conformance/suite.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": "1.0",
+  "suiteId": "nexcanvas-core-2026.09",
+  "description": "Provider-neutral cases covering the five semantic intents and sparse-to-dense compositions.",
+  "cases": [
+    {
+      "id": "dense-cloud-architecture",
+      "title": "Dense cloud reference architecture",
+      "baselineProject": "examples/v3-dense-industrial-ai",
+      "prompt": {"language": "en", "text": "Create an editable reference-grade architecture diagram for connected-factory analytics. Show operational sources, streaming ingestion, durable stores, hot and cold processing, model training, real-time serving, business consumption, and a platform/governance foundation. Use verified Azure service icons and clearly labeled independent connector lanes."},
+      "expectations": {"viewIntent": "architecture", "allowedRoutes": ["ai-ml/mlops", "runtime-cloud/cloud-reference"], "minNodes": 18, "minEdges": 14, "requiredConcepts": [["connected equipment", "production equipment"], ["event hubs"], ["storage", "data lake"], ["machine learning"], ["monitor"]], "requiredEdgePairs": [{"source": ["event hubs", "iot hub"], "target": ["stream analytics", "storage"]}], "requiredAssetKeys": ["azure-event-hubs", "azure-machine-learning", "azure-monitor"], "requiresLayoutBrainstorm": true}
+    },
+    {
+      "id": "multi-agent-workflow",
+      "title": "Multi-agent orchestration workflow",
+      "baselineProject": "examples/v5-multi-agent-workflow",
+      "prompt": {"language": "en", "text": "Create an editable workflow for a multi-agent system. One orchestrator plans and delegates to parallel specialist agents, a reviewer can trigger a bounded retry, high-risk work escalates to a human, and approved results are returned with telemetry and durable memory."},
+      "expectations": {"viewIntent": "workflow", "allowedRoutes": ["ai-ml/agent-orchestration", "behavior/bpmn"], "minNodes": 10, "minEdges": 9, "requiredConcepts": [["orchestrator"], ["research agent", "specialist agent"], ["review"], ["retry"], ["human approval", "human"], ["telemetry"]], "requiredEdgePairs": [{"source": ["orchestrator"], "target": ["research agent", "data and tool agent", "specialist agent"]}], "requiredAssetKeys": ["generic-orchestrator", "generic-agent", "generic-review"], "requiresLayoutBrainstorm": true}
+    },
+    {
+      "id": "grounded-answer-sequence",
+      "title": "Grounded answer request sequence",
+      "prompt": {"language": "en", "text": "Draw one request sequence for a grounded AI answer. Include user, API, policy check, retriever, vector store, model, citation validator, telemetry, timeout, fallback, and the final response. Distinguish synchronous calls, asynchronous telemetry, and returns."},
+      "expectations": {"viewIntent": "sequence", "allowedRoutes": ["behavior/sequence", "behavior/request-trace", "ai-ml/inference-trace"], "minNodes": 7, "minEdges": 8, "requiredConcepts": [["user"], ["api"], ["retriever", "search"], ["vector store", "index"], ["model"], ["citation", "validator"], ["telemetry"]], "requiredEdgePairs": [{"source": ["api"], "target": ["retriever", "search"]}], "requiredAssetKeys": [], "requiresLayoutBrainstorm": true}
+    },
+    {
+      "id": "event-analytics-data-flow",
+      "title": "Event analytics data flow",
+      "prompt": {"language": "en", "text": "Draw a data-flow view from devices and business systems through event ingestion, validation, stream and batch transformations, bronze/silver/gold stores, analytical serving, dashboards, and governed archival. Label important payloads and lineage."},
+      "expectations": {"viewIntent": "data-flow", "allowedRoutes": ["data/streaming", "data/etl-elt", "data/lakehouse-medallion"], "minNodes": 10, "minEdges": 9, "requiredConcepts": [["devices", "sensors"], ["event"], ["bronze"], ["silver"], ["gold"], ["dashboard", "analytics"], ["archive"]], "requiredEdgePairs": [{"source": ["bronze"], "target": ["silver"]}, {"source": ["silver"], "target": ["gold"]}], "requiredAssetKeys": [], "requiresLayoutBrainstorm": true}
+    },
+    {
+      "id": "model-release-lifecycle",
+      "title": "Model release lifecycle",
+      "prompt": {"language": "en", "text": "Draw the lifecycle of a machine-learning model from candidate through training, evaluation, approval, registry, staged deployment, monitoring, rollback or retraining, deprecation, and retirement. Show transition triggers and terminal states."},
+      "expectations": {"viewIntent": "lifecycle", "allowedRoutes": ["ai-ml/ml-lifecycle", "behavior/state-machine"], "minNodes": 8, "minEdges": 8, "requiredConcepts": [["candidate"], ["training"], ["evaluation"], ["approval"], ["registry"], ["deployment"], ["monitor"], ["retire"]], "requiredEdgePairs": [{"source": ["evaluation"], "target": ["approval"]}, {"source": ["monitor"], "target": ["retrain", "training", "rollback"]}], "requiredAssetKeys": [], "requiresLayoutBrainstorm": true}
+    }
+  ]
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 # Unified command-line interface
 
 The `nexcanvas` command is the supported automation surface for the technical
-preview. Product `v0.5.x` creates canonical diagram model `3.0`, reads legacy
+preview. Product `v0.6.x` creates canonical diagram model `3.0`, reads legacy
 diagram model `2.0`, and keeps source, lock, asset, pipeline-state, and editable
 Draw.io contracts at their existing versions. Repository sync requires V3.
 
@@ -55,6 +55,10 @@ python <skill-root>/scripts/nexcanvas_cli.py <command> [...]
 | `migrate v2-to-v3` | Write a separate canonical V3 model from a legacy V2 model |
 | `intent` | Infer a semantic view intent as an agent routing hint |
 | `contract` | Validate a persisted V2/V3 diagram contract or another supported contract |
+| `conformance doctor` | Detect locally available host adapters without claiming a passing run |
+| `conformance prepare` | Create a host/case run pack bound to the skill, adapter, and corpus digests |
+| `conformance evaluate` | Score a fixture or observed project across the five conformance dimensions |
+| `conformance report` | Aggregate observed results into a truthful host capability matrix |
 | `asset search` | Search the pinned technology icon catalog |
 | `asset sync` | Resolve a verified catalog, provider, or user-owned SVG asset |
 
@@ -160,6 +164,30 @@ unchanged. Every apply writes `reports/semantic_sync.json`, updates analyzer fac
 in `source_model.json`, and refreshes `diagram_lock.json.sourceHash`. Run
 `generate --repo-root` afterwards to rebuild and visually verify the artifact.
 
+## Cross-agent conformance
+
+Prepare a run pack from the bundled five-intent corpus:
+
+```bash
+nexcanvas conformance doctor
+nexcanvas conformance prepare <case-id> --host <host-id> --output <run-pack>
+```
+
+After the named host completes the generated `PROMPT.md`, retain its transcript,
+fill `execution.json`, and evaluate the untouched project:
+
+```bash
+nexcanvas conformance evaluate <run-pack>/request.json \
+  --project <run-pack>/project \
+  --mode observed \
+  --execution <run-pack>/execution.json \
+  --output <run-pack>/result.json
+```
+
+`--mode fixture` is reserved for evaluator tests and always emits status
+`fixture`, even when every dimension passes. `conformance report` ignores fixture
+results when determining host status. See [cross-agent conformance](conformance.md).
+
 ## Compatibility
 
 The `python scripts/*.py` interfaces published in `v0.1.x` remain as thin
@@ -170,7 +198,7 @@ only after the documented deprecation window.
 The importable modules under `src/nexcanvas` are implementation details; the
 technical preview does not yet publish a stable Python API.
 
-Diagram model `2.0` remains readable throughout `v0.5.x`. New `init` output uses
+Diagram model `2.0` remains readable throughout `v0.6.x`. New `init` output uses
 diagram model `3.0`; source model and diagram lock remain schema `2.0`, while
 pipeline state, repository snapshot, and semantic sync plan use independent
 schema `1.0` contracts. Incremental sync requires V3.
@@ -184,8 +212,10 @@ schema `1.0` contracts. Incremental sync requires V3.
 - Semantic authoring and visual judgment remain agent/human responsibilities;
   `generate` orchestrates deterministic stages but does not invent architecture
   facts or automatically approve aesthetics.
-- The `v0.5.x` pipeline fingerprints the complete diagram-model file, so a
+- The `v0.6.x` pipeline fingerprints the complete diagram-model file, so a
   presentation-only edit conservatively reruns every delivery stage even though
   its semantics-only fingerprint remains stable.
 - Phase 5 analyzers expose module/import evidence only. They do not infer dynamic
   runtime calls, framework routing, ownership, deployment, or production state.
+- A bundled adapter and local executable detection do not prove host conformance.
+  Only complete, current observed corpus runs can produce `verified` status.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,60 @@
+# Cross-agent conformance
+
+NexCanvas separates portable instructions from measurable execution. Codex,
+GitHub Copilot, Claude Code, and other Agent Skills hosts all consume the same
+root `SKILL.md`; host descriptors under `conformance/hosts/` contain discovery
+and evidence metadata only.
+
+## What is measured
+
+Each corpus result exposes five unweighted dimensions. All must score `1.0` for
+the run to pass:
+
+| Dimension | Observable checks |
+|---|---|
+| Semantics | minimum graph coverage, required concepts, and required relationships |
+| Evidence | confirmed source contract, grounded facts, and fact references on primary semantics |
+| Assets | valid manifest, resolved embedded/render-verified references, and required exact assets |
+| Routing | valid model and lock, correct semantic intent/profile, lock alignment, and layout brainstorm |
+| Gates | editable Draw.io, render, diagram QA, explicit visual approval, and live postflight |
+
+The pass threshold is intentionally conjunctive. An attractive render cannot
+hide missing evidence, and a semantically correct model cannot hide an unfinished
+visual gate.
+
+## Corpus design
+
+`conformance/suite.json` covers architecture, workflow, sequence, data flow, and
+lifecycle. Cases specify semantic invariants rather than coordinates or exact XML,
+so hosts may make legitimate presentation choices while remaining comparable.
+The dense architecture and multi-agent workflow cases point to tracked reference
+projects used as evaluator fixtures. These fixtures verify the scorer, not a host.
+
+## Result trust model
+
+There are four matrix states:
+
+- `verified`: an observed passing run with hash-bound execution evidence;
+- `failed`: an observed run failed at least one required dimension;
+- `not-run`: the adapter is defined but no current observed result exists;
+- `unavailable`: the host executable is not visible in the inspected environment.
+
+An observed record binds the host/case identity, timestamps, invocation surface,
+request, skill, adapter, corpus case, and evidence files by SHA-256. Result
+digests additionally bind the evaluated project artifacts. A change to any
+versioned input makes an older result historical rather than current proof.
+
+## Why output is not byte-identical
+
+The agent owns interpretation, evidence investigation, and rendered-image review.
+The deterministic core owns contracts, compilation, structural QA, hashes, and
+gate order. Different hosts may choose different valid wording or geometry, so
+conformance evaluates the communicated meaning and delivery guarantees instead
+of requiring identical Draw.io XML.
+
+## Current published status
+
+The repository ships adapters and a deterministic conformance harness. No host is
+declared verified by fixture data. See the generated
+[published host capability matrix](host-capability-matrix.md) and the
+[execution workflow](../workflows/conformance.md).

--- a/docs/host-capability-matrix.md
+++ b/docs/host-capability-matrix.md
@@ -1,0 +1,12 @@
+# Host capability and conformance matrix
+
+Suite: `nexcanvas-core-2026.09`. A `verified` state requires observed execution evidence; fixtures never change host status.
+
+| Host | Published state | Execution | Discovery paths | Verified cases | Limitations |
+|---|---|---|---|---|---|
+| OpenAI Codex | **not-run** | automated-cli | `.agents/skills/nexcanvas-drawio`<br>`$HOME/.agents/skills/nexcanvas-drawio`<br>`$CODEX_HOME/skills/nexcanvas-drawio`<br>`~/.codex/skills/nexcanvas-drawio` | None | Tool availability and approval policy vary by Codex environment. |
+| GitHub Copilot | **not-run** | manual-export | `.github/skills/nexcanvas-drawio`<br>`.agents/skills/nexcanvas-drawio` | None | GitHub, IDE, coding-agent, and CLI surfaces can expose different tools and permissions. |
+| Claude Code | **not-run** | automated-cli | `.claude/skills/nexcanvas-drawio` | None | Tool permissions, model selection, and project trust settings affect execution. |
+| Compatible Agent Skills host | **not-run** | manual-export | `host-defined skill directory` | None | Discovery, invocation, and tool permissions are host-defined until a dedicated adapter is published. |
+
+Local availability is diagnostic only. It is not proof that a host completed the NexCanvas workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ version = { attr = "nexcanvas.__version__" }
 where = ["src"]
 
 [tool.setuptools.data-files]
+"share/nexcanvas" = ["SKILL.md"]
 "share/nexcanvas/config" = ["config/*.json"]
 "share/nexcanvas/assets/catalog" = ["assets/catalog/*.json"]
 "share/nexcanvas/schemas" = ["schemas/*.json"]
+"share/nexcanvas/conformance" = ["conformance/*.json"]
+"share/nexcanvas/conformance/hosts" = ["conformance/hosts/*.json"]
 

--- a/schemas/conformance-execution.schema.json
+++ b/schemas/conformance-execution.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexcanvas.dev/schemas/conformance-execution.schema.json",
+  "title": "NexCanvas Conformance Execution Record",
+  "type": "object",
+  "required": ["schemaVersion", "mode", "hostId", "hostVersion", "surface", "caseId", "startedAt", "completedAt", "requestSha256", "skillSha256", "adapterSha256", "caseSha256", "invocation", "evidence"],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "mode": {"const": "observed"},
+    "hostId": {"type": "string"},
+    "hostVersion": {"type": "string", "minLength": 1},
+    "surface": {"type": "string", "minLength": 1},
+    "caseId": {"type": "string"},
+    "startedAt": {"type": "string"},
+    "completedAt": {"type": "string"},
+    "requestSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "skillSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "adapterSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "caseSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "invocation": {"type": "string", "minLength": 1},
+    "evidence": {"type": "array", "minItems": 1, "items": {"type": "object", "required": ["path", "sha256"]}}
+  },
+  "additionalProperties": false
+}

--- a/schemas/conformance-result.schema.json
+++ b/schemas/conformance-result.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexcanvas.dev/schemas/conformance-result.schema.json",
+  "title": "NexCanvas Conformance Result",
+  "type": "object",
+  "required": ["schemaVersion", "resultId", "mode", "status", "hostId", "caseId", "digests", "dimensions", "passed", "evaluatedAt"],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "resultId": {"type": "string"},
+    "mode": {"enum": ["fixture", "observed"]},
+    "status": {"enum": ["fixture", "verified", "failed"]},
+    "hostId": {"type": "string"},
+    "caseId": {"type": "string"},
+    "digests": {"type": "object"},
+    "dimensions": {"type": "object"},
+    "passed": {"type": "boolean"},
+    "evaluatedAt": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/schemas/conformance-suite.schema.json
+++ b/schemas/conformance-suite.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexcanvas.dev/schemas/conformance-suite.schema.json",
+  "title": "NexCanvas Conformance Suite",
+  "type": "object",
+  "required": ["schemaVersion", "suiteId", "cases"],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "suiteId": {"type": "string", "minLength": 1},
+    "description": {"type": "string"},
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "prompt", "expectations"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$"},
+          "title": {"type": "string", "minLength": 1},
+          "prompt": {"type": "object", "required": ["language", "text"]},
+          "expectations": {"type": "object"},
+          "baselineProject": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/host-adapter.schema.json
+++ b/schemas/host-adapter.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexcanvas.dev/schemas/host-adapter.schema.json",
+  "title": "NexCanvas Host Adapter",
+  "type": "object",
+  "required": ["schemaVersion", "id", "displayName", "sharedSkill", "discoveryPaths", "execution", "evidence", "limitations"],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$"},
+    "displayName": {"type": "string", "minLength": 1},
+    "sharedSkill": {"const": "SKILL.md"},
+    "docsUrl": {"type": "string"},
+    "discoveryPaths": {"type": "array", "items": {"type": "string"}},
+    "executableNames": {"type": "array", "items": {"type": "string"}},
+    "execution": {"enum": ["automated-cli", "manual-export"]},
+    "evidence": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "limitations": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": false
+}

--- a/scripts/package_smoke.py
+++ b/scripts/package_smoke.py
@@ -52,8 +52,14 @@ def _assert_cli(environment: Path, outside: Path) -> tuple[str, dict[str, object
     _run([str(command), "analyze", "snapshot", "--help"], outside)
     _run([str(command), "analyze", "diff", "--help"], outside)
     _run([str(command), "sync", "--help"], outside)
+    conformance = json.loads(_run([str(command), "conformance", "doctor"], outside).stdout)
+    _run([str(command), "conformance", "prepare", "--help"], outside)
+    _run([str(command), "conformance", "evaluate", "--help"], outside)
+    _run([str(command), "conformance", "report", "--no-discovery"], outside)
     if not doctor["capabilities"]["authorNativeDrawio"] or catalog["count"] != 1:
         raise RuntimeError("Installed runtime data or core capability checks failed.")
+    if len(conformance.get("hosts", [])) < 4:
+        raise RuntimeError("Installed runtime is missing conformance host adapters.")
     return version, doctor
 
 
@@ -132,7 +138,14 @@ def main() -> int:
         )
         if not state_contract["ok"]:
             raise RuntimeError("Packaged CLI created an invalid project pipeline state contract.")
-        for schema in ("repository-snapshot.schema.json", "semantic-sync-plan.schema.json"):
+        for schema in (
+            "repository-snapshot.schema.json",
+            "semantic-sync-plan.schema.json",
+            "conformance-suite.schema.json",
+            "host-adapter.schema.json",
+            "conformance-execution.schema.json",
+            "conformance-result.schema.json",
+        ):
             if not (Path(doctor["skillRoot"]) / "schemas" / schema).is_file():
                 raise RuntimeError(f"Packaged runtime is missing {schema}.")
         print(

--- a/scripts/validate_conformance.py
+++ b/scripts/validate_conformance.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Validate the Phase 6 corpus, adapters, fixtures, and reporting invariants."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from nexcanvas.conformance import build_matrix, evaluate_run, load_adapters, load_suite, matrix_markdown, prepare_run
+
+
+def main() -> int:
+    suite = load_suite(ROOT)
+    adapters = load_adapters(ROOT)
+    failures: list[str] = []
+    baselines = [case for case in suite["cases"] if case.get("baselineProject")]
+    with tempfile.TemporaryDirectory() as directory:
+        temp = Path(directory)
+        for case in baselines:
+            pack = temp / case["id"]
+            prepare_run(case["id"], "codex", pack, ROOT)
+            result = evaluate_run(
+                pack / "request.json",
+                ROOT / case["baselineProject"],
+                mode="fixture",
+                root=ROOT,
+            )
+            if not result["passed"] or result["status"] != "fixture":
+                failures.append(f"fixture failed: {case['id']}")
+        matrix = build_matrix([], detect=False, root=ROOT)
+        if any(host["state"] != "not-run" for host in matrix["hosts"]):
+            failures.append("empty observed result set must leave every host not-run")
+        if "fixtures never change host status" not in matrix_markdown(matrix):
+            failures.append("matrix disclosure is missing")
+    if failures:
+        print("NexCanvas conformance validation failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print(
+        f"NexCanvas conformance validation passed: {len(suite['cases'])} cases, "
+        f"{len(adapters)} adapters, {len(baselines)} fixture baselines."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/validate_skill.py
+++ b/scripts/validate_skill.py
@@ -73,8 +73,19 @@ def validate() -> list[str]:
         "schemas/diagram-model-v3.schema.json",
         "schemas/repository-snapshot.schema.json",
         "schemas/semantic-sync-plan.schema.json",
+        "schemas/conformance-suite.schema.json",
+        "schemas/host-adapter.schema.json",
+        "schemas/conformance-execution.schema.json",
+        "schemas/conformance-result.schema.json",
+        "conformance/suite.json",
+        "conformance/hosts/codex.json",
+        "conformance/hosts/github-copilot.json",
+        "conformance/hosts/claude-code.json",
+        "docs/conformance.md",
+        "docs/host-capability-matrix.md",
         "docs/pipeline-state.md",
         "references/semantic-model-v3.md",
+        "workflows/conformance.md",
         "workflows/sync-repository.md",
         "version.txt",
         "release-please-config.json",
@@ -140,6 +151,15 @@ def validate() -> list[str]:
     legacy_core = [path for path in (ROOT / "scripts" / "nexcanvas").glob("*.py") if path.name != "__init__.py"]
     if legacy_core:
         issues.append(f"legacy implementation modules remain under scripts/nexcanvas: {legacy_core}")
+
+    sys.path.insert(0, str(ROOT / "src"))
+    try:
+        from nexcanvas.conformance import load_adapters, load_suite
+
+        load_suite(ROOT)
+        load_adapters(ROOT)
+    except (OSError, ValueError) as exc:
+        issues.append(f"conformance contracts are invalid: {exc}")
 
     return issues
 

--- a/scripts/validate_skill.py
+++ b/scripts/validate_skill.py
@@ -143,6 +143,10 @@ def validate() -> list[str]:
         "CONTRIBUTING.md",
         "SECURITY.md",
         "SUPPORT.md",
+        "docs/cli.md",
+        "docs/conformance.md",
+        "docs/host-capability-matrix.md",
+        "workflows/conformance.md",
     ]:
         path = ROOT / relative
         if path.is_file():

--- a/src/nexcanvas/cli.py
+++ b/src/nexcanvas/cli.py
@@ -10,6 +10,7 @@ from . import __version__
 from .assets import load_catalog, search_catalog, sync_catalog_asset, sync_provider_asset, sync_user_asset
 from .builder import build_drawio
 from .common import load_json, utc_now, write_json
+from .conformance import build_matrix, evaluate_run, host_capabilities, matrix_markdown, prepare_run
 from .contracts import validate_file, validate_repository_snapshot
 from .geometry import run_checks as run_geometry_checks
 from .intents import DEFAULT_ROUTES, VIEW_INTENTS, classify_brief
@@ -255,6 +256,38 @@ def _contract(args: argparse.Namespace) -> int:
     return 0 if report["ok"] else 1
 
 
+def _conformance_doctor(args: argparse.Namespace) -> int:
+    _emit(host_capabilities(), args.output)
+    return 0
+
+
+def _conformance_prepare(args: argparse.Namespace) -> int:
+    _emit(prepare_run(args.case, args.host, args.output.resolve()))
+    return 0
+
+
+def _conformance_evaluate(args: argparse.Namespace) -> int:
+    result = evaluate_run(
+        args.request.resolve(),
+        args.project.resolve(),
+        mode=args.mode,
+        execution_path=args.execution.resolve() if args.execution else None,
+    )
+    _emit(result, args.output)
+    return 0 if result["passed"] else 1
+
+
+def _conformance_report(args: argparse.Namespace) -> int:
+    results = [load_json(path.resolve()) for path in args.results]
+    matrix = build_matrix(results, detect=not args.no_discovery)
+    if args.markdown:
+        markdown = matrix_markdown(matrix)
+        args.markdown.resolve().parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.resolve().write_text(markdown, encoding="utf-8", newline="\n")
+    _emit(matrix, args.output)
+    return 0
+
+
 def _asset_search(args: argparse.Namespace) -> int:
     results = search_catalog(args.query, limit=args.limit) if args.query else load_catalog().get("entries", [])[: args.limit]
     _emit({"count": len(results), "results": results})
@@ -445,6 +478,30 @@ def build_parser() -> argparse.ArgumentParser:
     contract.add_argument("path", type=Path)
     contract.add_argument("--project-root", type=Path)
     _set_handler(contract, _contract)
+
+    conformance = commands.add_parser("conformance", help="Prepare, evaluate, and report evidence-based host conformance.")
+    conformance_commands = conformance.add_subparsers(dest="conformance_command", required=True)
+    conformance_doctor = conformance_commands.add_parser("doctor", help="Inspect local host adapter availability.")
+    conformance_doctor.add_argument("--output", type=Path)
+    _set_handler(conformance_doctor, _conformance_doctor)
+    conformance_prepare = conformance_commands.add_parser("prepare", help="Create a hash-bound host run pack for one corpus case.")
+    conformance_prepare.add_argument("case")
+    conformance_prepare.add_argument("--host", required=True)
+    conformance_prepare.add_argument("--output", type=Path, required=True)
+    _set_handler(conformance_prepare, _conformance_prepare)
+    conformance_evaluate = conformance_commands.add_parser("evaluate", help="Score one completed conformance project.")
+    conformance_evaluate.add_argument("request", type=Path)
+    conformance_evaluate.add_argument("--project", type=Path, required=True)
+    conformance_evaluate.add_argument("--mode", choices=["fixture", "observed"], required=True)
+    conformance_evaluate.add_argument("--execution", type=Path)
+    conformance_evaluate.add_argument("--output", type=Path)
+    _set_handler(conformance_evaluate, _conformance_evaluate)
+    conformance_report = conformance_commands.add_parser("report", help="Aggregate observed results into a host matrix.")
+    conformance_report.add_argument("results", type=Path, nargs="*")
+    conformance_report.add_argument("--no-discovery", action="store_true", help="Report not-run instead of machine-local unavailable.")
+    conformance_report.add_argument("--output", type=Path)
+    conformance_report.add_argument("--markdown", type=Path)
+    _set_handler(conformance_report, _conformance_report)
 
     asset = commands.add_parser("asset", help="Search or sync verified diagram assets.")
     asset_commands = asset.add_subparsers(dest="asset_command", required=True)

--- a/src/nexcanvas/conformance.py
+++ b/src/nexcanvas/conformance.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from .common import load_json, portable_path, resource_root, sha256_file, sha256_json, utc_now, write_json
+from .contracts import validate_diagram_model, validate_lock, validate_manifest, validate_source_model
+from .model_v3 import normalize_diagram_model
+from .postflight import run_postflight
+
+
+DIMENSIONS = ("semantics", "evidence", "assets", "routing", "gates")
+PASS_THRESHOLD = 1.0
+HOST_STATES = {"verified", "not-run", "unavailable", "failed"}
+HASH_KEYS = {"skillSha256", "adapterSha256", "caseSha256", "requestSha256", "projectArtifactsSha256"}
+
+
+def _data_root(root: Path | None = None) -> Path:
+    return (root or resource_root()) / "conformance"
+
+
+def load_suite(root: Path | None = None) -> dict[str, Any]:
+    suite = load_json(_data_root(root) / "suite.json")
+    errors = validate_suite(suite)
+    if errors:
+        raise ValueError(f"Invalid conformance suite: {errors[0]}")
+    return suite
+
+
+def load_adapters(root: Path | None = None) -> list[dict[str, Any]]:
+    adapters: list[dict[str, Any]] = []
+    for path in sorted((_data_root(root) / "hosts").glob("*.json")):
+        adapter = load_json(path)
+        errors = validate_adapter(adapter)
+        if errors:
+            raise ValueError(f"Invalid host adapter {path.name}: {errors[0]}")
+        adapter["_path"] = path
+        adapters.append(adapter)
+    return adapters
+
+
+def validate_suite(suite: Any) -> list[str]:
+    issues: list[str] = []
+    if not isinstance(suite, dict) or suite.get("schemaVersion") != "1.0":
+        return ["schemaVersion must be '1.0'."]
+    if not isinstance(suite.get("suiteId"), str) or not suite["suiteId"].strip():
+        issues.append("suiteId must be a non-empty string.")
+    cases = suite.get("cases")
+    if not isinstance(cases, list) or not cases:
+        return issues + ["cases must be a non-empty array."]
+    ids: set[str] = set()
+    intents: set[str] = set()
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            issues.append(f"cases[{index}] must be an object.")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            issues.append(f"cases[{index}].id must be a non-empty string.")
+        elif case_id in ids:
+            issues.append(f"Duplicate case id: {case_id}.")
+        else:
+            ids.add(case_id)
+        prompt = case.get("prompt")
+        if not isinstance(prompt, dict) or not all(isinstance(prompt.get(key), str) and prompt[key].strip() for key in ("language", "text")):
+            issues.append(f"cases[{index}].prompt requires non-empty language and text.")
+        expected = case.get("expectations")
+        if not isinstance(expected, dict):
+            issues.append(f"cases[{index}].expectations must be an object.")
+            continue
+        intent = expected.get("viewIntent")
+        if isinstance(intent, str):
+            intents.add(intent)
+        for key in ("minNodes", "minEdges"):
+            if not isinstance(expected.get(key), int) or expected[key] < 0:
+                issues.append(f"cases[{index}].expectations.{key} must be a non-negative integer.")
+    required_intents = {"architecture", "workflow", "sequence", "data-flow", "lifecycle"}
+    missing = required_intents - intents
+    if missing:
+        issues.append(f"Suite does not cover intents: {', '.join(sorted(missing))}.")
+    return issues
+
+
+def validate_adapter(adapter: Any) -> list[str]:
+    if not isinstance(adapter, dict) or adapter.get("schemaVersion") != "1.0":
+        return ["schemaVersion must be '1.0'."]
+    issues: list[str] = []
+    for key in ("id", "displayName"):
+        if not isinstance(adapter.get(key), str) or not adapter[key].strip():
+            issues.append(f"{key} must be a non-empty string.")
+    if adapter.get("sharedSkill") != "SKILL.md":
+        issues.append("sharedSkill must be SKILL.md; adapters cannot fork the workflow.")
+    if adapter.get("execution") not in {"automated-cli", "manual-export"}:
+        issues.append("execution must be automated-cli or manual-export.")
+    for key in ("discoveryPaths", "evidence", "limitations"):
+        if not isinstance(adapter.get(key), list):
+            issues.append(f"{key} must be an array.")
+    return issues
+
+
+def validate_result(result: Any) -> list[str]:
+    if not isinstance(result, dict) or result.get("schemaVersion") != "1.0":
+        return ["conformance result schemaVersion must be '1.0'."]
+    issues: list[str] = []
+    mode = result.get("mode")
+    status = result.get("status")
+    if mode not in {"fixture", "observed"}:
+        issues.append("mode must be fixture or observed.")
+    if status not in {"fixture", "verified", "failed"}:
+        issues.append("status must be fixture, verified, or failed.")
+    if mode == "fixture" and status != "fixture":
+        issues.append("Fixture results must use status fixture.")
+    if mode == "observed" and status not in {"verified", "failed"}:
+        issues.append("Observed results must use status verified or failed.")
+    if mode == "observed" and not isinstance(result.get("execution"), dict):
+        issues.append("Observed results must embed their execution record.")
+    for key in ("resultId", "hostId", "caseId", "evaluatedAt"):
+        if not isinstance(result.get(key), str) or not result[key].strip():
+            issues.append(f"{key} must be a non-empty string.")
+    dimensions = result.get("dimensions")
+    if not isinstance(dimensions, dict) or set(dimensions) != set(DIMENSIONS):
+        issues.append(f"dimensions must contain exactly: {', '.join(DIMENSIONS)}.")
+    else:
+        scores = []
+        for name in DIMENSIONS:
+            score = dimensions[name].get("score") if isinstance(dimensions[name], dict) else None
+            if not isinstance(score, (int, float)) or isinstance(score, bool) or not 0 <= score <= 1:
+                issues.append(f"dimensions.{name}.score must be between 0 and 1.")
+            else:
+                scores.append(float(score))
+        expected_pass = len(scores) == len(DIMENSIONS) and all(score >= PASS_THRESHOLD for score in scores)
+        if result.get("passed") is not expected_pass:
+            issues.append("passed does not match the dimension threshold.")
+        if mode == "observed" and status == "verified" and not expected_pass:
+            issues.append("A verified result must pass every dimension.")
+        if mode == "observed" and status == "failed" and expected_pass:
+            issues.append("A failed result must fail at least one dimension.")
+    digests = result.get("digests")
+    if not isinstance(digests, dict) or not HASH_KEYS.issubset(digests):
+        issues.append("digests must bind the skill, adapter, case, request, and project artifacts.")
+    elif any(not isinstance(digests[key], str) or len(digests[key]) != 64 for key in HASH_KEYS):
+        issues.append("Every conformance digest must be a 64-character SHA-256 value.")
+    return issues
+
+
+def host_capabilities(root: Path | None = None) -> dict[str, Any]:
+    hosts = []
+    for adapter in load_adapters(root):
+        executables = adapter.get("executableNames", [])
+        resolved = {name: shutil.which(name) for name in executables}
+        available = any(resolved.values()) if executables else False
+        hosts.append(
+            {
+                "id": adapter["id"],
+                "displayName": adapter["displayName"],
+                "available": available,
+                "state": "not-run" if available else "unavailable",
+                "execution": adapter["execution"],
+                "discoveryPaths": adapter["discoveryPaths"],
+                "executables": resolved,
+                "limitations": adapter["limitations"],
+            }
+        )
+    return {"schemaVersion": "1.0", "checkedAt": utc_now(), "hosts": hosts}
+
+
+def prepare_run(case_id: str, host_id: str, output: Path, root: Path | None = None) -> dict[str, Any]:
+    distribution = root or resource_root()
+    suite = load_suite(distribution)
+    cases = {case["id"]: case for case in suite["cases"]}
+    adapters = {adapter["id"]: adapter for adapter in load_adapters(distribution)}
+    if case_id not in cases:
+        raise ValueError(f"Unknown conformance case: {case_id}")
+    if host_id not in adapters:
+        raise ValueError(f"Unknown conformance host: {host_id}")
+    case = cases[case_id]
+    adapter = adapters[host_id]
+    skill_path = distribution / "SKILL.md"
+    adapter_path = Path(adapter["_path"])
+    request = {
+        "schemaVersion": "1.0",
+        "suiteId": suite["suiteId"],
+        "hostId": host_id,
+        "caseId": case_id,
+        "createdAt": utc_now(),
+        "digests": {
+            "skillSha256": sha256_file(skill_path),
+            "adapterSha256": sha256_file(adapter_path),
+            "caseSha256": sha256_json(case),
+        },
+        "prompt": case["prompt"],
+        "expectedOutput": "project",
+    }
+    output.mkdir(parents=True, exist_ok=True)
+    write_json(output / "request.json", request)
+    template = {
+        "schemaVersion": "1.0",
+        "mode": "observed",
+        "hostId": host_id,
+        "hostVersion": "REPLACE_WITH_HOST_VERSION",
+        "surface": "REPLACE_WITH_HOST_SURFACE",
+        "caseId": case_id,
+        "startedAt": "REPLACE_WITH_UTC_TIMESTAMP",
+        "completedAt": "REPLACE_WITH_UTC_TIMESTAMP",
+        "requestSha256": sha256_file(output / "request.json"),
+        **request["digests"],
+        "invocation": "REPLACE_WITH_HOST_AND_SURFACE",
+        "evidence": [{"path": "REPLACE_WITH_TRANSCRIPT_OR_TASK_EXPORT", "sha256": "REPLACE_WITH_SHA256"}],
+    }
+    write_json(output / "execution.template.json", template)
+    prompt = (
+        f"Use the installed NexCanvas Draw.io skill to complete this conformance case.\n\n"
+        f"{case['prompt']['text']}\n\n"
+        "Requirements:\n"
+        "- Follow the shared SKILL.md workflow; do not substitute Mermaid or a flattened image.\n"
+        "- Write the complete editable project to the `project` directory beside request.json.\n"
+        "- Run every applicable NexCanvas QA and postflight gate.\n"
+        "- Preserve the session/task transcript as an evidence file.\n"
+        "- Fill execution.template.json and save it as execution.json only after the run.\n"
+    )
+    (output / "PROMPT.md").write_text(prompt, encoding="utf-8", newline="\n")
+    return {"request": portable_path(output / "request.json"), "prompt": portable_path(output / "PROMPT.md")}
+
+
+def _text(value: Any) -> str:
+    return " ".join(str(value or "").lower().split())
+
+
+def _score(checks: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    values = list(checks)
+    passed = sum(bool(item["ok"]) for item in values)
+    return {"score": round(passed / len(values), 4) if values else 1.0, "passed": passed, "total": len(values), "checks": values}
+
+
+def _check(name: str, ok: bool, detail: str) -> dict[str, Any]:
+    return {"name": name, "ok": bool(ok), "detail": detail}
+
+
+def _model_parts(model: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    projection = normalize_diagram_model(model)
+    return list(projection.get("nodes", [])), list(projection.get("edges", []))
+
+
+def _matches(node: dict[str, Any], aliases: list[str]) -> bool:
+    haystack = _text(f"{node.get('label', '')} {node.get('caption', '')} {node.get('id', '')}")
+    return any(_text(alias) in haystack for alias in aliases)
+
+
+def _semantic_checks(model: dict[str, Any], expected: dict[str, Any]) -> list[dict[str, Any]]:
+    nodes, edges = _model_parts(model)
+    checks = [
+        _check("minimum-nodes", len(nodes) >= expected["minNodes"], f"{len(nodes)} >= {expected['minNodes']}"),
+        _check("minimum-edges", len(edges) >= expected["minEdges"], f"{len(edges)} >= {expected['minEdges']}"),
+    ]
+    by_id = {str(node.get("id")): node for node in nodes}
+    for index, aliases in enumerate(expected.get("requiredConcepts", []), 1):
+        found = any(_matches(node, aliases) for node in nodes)
+        checks.append(_check(f"required-concept-{index}", found, " | ".join(aliases)))
+    for index, pair in enumerate(expected.get("requiredEdgePairs", []), 1):
+        found = False
+        for edge in edges:
+            source = by_id.get(str(edge.get("source")), {})
+            target = by_id.get(str(edge.get("target")), {})
+            if _matches(source, pair["source"]) and _matches(target, pair["target"]):
+                found = True
+                break
+        checks.append(_check(f"required-edge-{index}", found, f"{pair['source']} -> {pair['target']}"))
+    return checks
+
+
+def _evidence_checks(source: dict[str, Any], model: dict[str, Any]) -> list[dict[str, Any]]:
+    nodes, edges = _model_parts(model)
+    facts = {str(fact.get("id")) for fact in source.get("facts", []) if isinstance(fact, dict)}
+    referenced = [item for item in [*nodes, *edges] if item.get("importance", "primary") == "primary"]
+    valid_refs = all(
+        isinstance(item.get("evidence"), list)
+        and bool(item["evidence"])
+        and all(str(reference) in facts for reference in item["evidence"])
+        for item in referenced
+    )
+    facts_grounded = all(
+        isinstance(fact.get("evidence"), list) and bool(fact["evidence"])
+        for fact in source.get("facts", [])
+        if isinstance(fact, dict)
+    )
+    return [
+        _check("source-confirmed", source.get("status") == "confirmed", str(source.get("status"))),
+        _check("source-contract", not any(issue.severity == "error" for issue in validate_source_model(source)), "source_model.json"),
+        _check("facts-grounded", bool(facts) and facts_grounded, f"{len(facts)} facts"),
+        _check("primary-semantics-grounded", bool(referenced) and valid_refs, f"{len(referenced)} primary items"),
+    ]
+
+
+def _asset_checks(project: Path, model: dict[str, Any], expected: dict[str, Any]) -> list[dict[str, Any]]:
+    manifest_path = project / "assets" / "asset_manifest.json"
+    if not manifest_path.is_file():
+        return [_check("asset-manifest", False, "assets/asset_manifest.json missing")]
+    manifest = load_json(manifest_path)
+    nodes, _ = _model_parts(model)
+    entries = {str(item.get("key")): item for item in manifest.get("assets", []) if isinstance(item, dict)}
+    checks = [_check("asset-contract", not any(issue.severity == "error" for issue in validate_manifest(manifest, project)), "asset_manifest.json")]
+    referenced = {str(node.get("assetRef")) for node in nodes if node.get("assetRef")}
+    checks.append(_check("referenced-assets-resolved", all(key in entries and entries[key].get("state") in {"Embedded", "RenderVerified"} for key in referenced), f"{len(referenced)} references"))
+    for key in expected.get("requiredAssetKeys", []):
+        entry = entries.get(key, {})
+        checks.append(_check(f"required-asset-{key}", entry.get("state") in {"Embedded", "RenderVerified"}, key))
+    return checks
+
+
+def _routing_checks(project: Path, model: dict[str, Any], lock: dict[str, Any], expected: dict[str, Any]) -> list[dict[str, Any]]:
+    projection = normalize_diagram_model(model)
+    route = projection.get("route", {})
+    route_key = f"{route.get('family')}/{route.get('profile')}"
+    intent = projection.get("viewIntent")
+    lock_route = lock.get("route", {})
+    lock_route_key = f"{lock_route.get('family')}/{lock_route.get('profile')}"
+    return [
+        _check("diagram-contract", not any(issue.severity == "error" for issue in validate_diagram_model(model)), "diagram_model.json"),
+        _check("lock-contract", not any(issue.severity == "error" for issue in validate_lock(lock)), "diagram_lock.json"),
+        _check("view-intent", intent == expected["viewIntent"], f"{intent!r} == {expected['viewIntent']!r}"),
+        _check("allowed-route", route_key in expected.get("allowedRoutes", []), route_key),
+        _check("lock-alignment", lock.get("viewIntent") == intent and lock_route_key == route_key, lock_route_key),
+        _check("layout-brainstorm", not expected.get("requiresLayoutBrainstorm") or (project / "reports" / "layout_brainstorm.json").is_file(), "reports/layout_brainstorm.json"),
+    ]
+
+
+def _gate_checks(project: Path) -> list[dict[str, Any]]:
+    diagram_qa = load_json(project / "reports" / "diagram_qa.json") if (project / "reports" / "diagram_qa.json").is_file() else {}
+    visual_qa = load_json(project / "reports" / "visual_qa.json") if (project / "reports" / "visual_qa.json").is_file() else {}
+    postflight = run_postflight(project)
+    visual = visual_qa.get("manualReview", {})
+    return [
+        _check("editable-drawio", (project / "artifacts" / "diagram.drawio").is_file(), "artifacts/diagram.drawio"),
+        _check("rendered-artifact", any((project / "artifacts").glob("diagram.drawio.*")), "artifacts/diagram.drawio.*"),
+        _check("diagram-qa", diagram_qa.get("ok") is True and diagram_qa.get("counts", {}).get("error") == 0, "reports/diagram_qa.json"),
+        _check("visual-qa", visual_qa.get("ok") is True and visual.get("status") == "approved", "reports/visual_qa.json"),
+        _check("live-postflight", postflight.get("ok") is True, f"errors={postflight.get('counts', {}).get('error', 0)}"),
+    ]
+
+
+def _validate_observed_execution(execution: dict[str, Any], request: dict[str, Any], request_path: Path) -> list[str]:
+    issues: list[str] = []
+    required = {"schemaVersion", "mode", "hostId", "hostVersion", "surface", "caseId", "startedAt", "completedAt", "requestSha256", "skillSha256", "adapterSha256", "caseSha256", "invocation", "evidence"}
+    missing = required - set(execution)
+    if missing:
+        return [f"Execution record is missing: {', '.join(sorted(missing))}."]
+    if execution.get("schemaVersion") != "1.0" or execution.get("mode") != "observed":
+        issues.append("Observed execution must use schemaVersion 1.0 and mode observed.")
+    if execution.get("hostId") != request.get("hostId") or execution.get("caseId") != request.get("caseId"):
+        issues.append("Execution hostId/caseId does not match the request.")
+    for key in ("hostVersion", "surface", "invocation"):
+        value = execution.get(key)
+        if not isinstance(value, str) or not value.strip() or value.startswith("REPLACE_WITH_"):
+            issues.append(f"Execution {key} must identify the real host run.")
+    timestamps = []
+    for key in ("startedAt", "completedAt"):
+        try:
+            value = str(execution.get(key, ""))
+            if not value.endswith("Z"):
+                raise ValueError
+            timestamps.append(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            issues.append(f"Execution {key} must be an ISO-8601 UTC timestamp.")
+    if len(timestamps) == 2 and timestamps[1] < timestamps[0]:
+        issues.append("Execution completedAt cannot precede startedAt.")
+    if execution.get("requestSha256") != sha256_file(request_path):
+        issues.append("Execution requestSha256 does not match request.json.")
+    for key in ("skillSha256", "adapterSha256", "caseSha256"):
+        if execution.get(key) != request.get("digests", {}).get(key):
+            issues.append(f"Execution {key} does not match request.json.")
+    evidence = execution.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        issues.append("Observed execution requires at least one evidence file.")
+    else:
+        for index, item in enumerate(evidence):
+            path = (request_path.parent / str(item.get("path", ""))).resolve()
+            digest = item.get("sha256")
+            if not path.is_file() or not isinstance(digest, str) or len(digest) != 64 or digest != sha256_file(path):
+                issues.append(f"Execution evidence[{index}] is missing or has a mismatched digest.")
+    return issues
+
+
+def evaluate_run(request_path: Path, project: Path, *, mode: str, execution_path: Path | None = None, root: Path | None = None) -> dict[str, Any]:
+    if mode not in {"fixture", "observed"}:
+        raise ValueError("mode must be fixture or observed.")
+    request = load_json(request_path)
+    distribution = root or resource_root()
+    suite = load_suite(distribution)
+    if request.get("suiteId") != suite["suiteId"]:
+        raise ValueError("Request suiteId is stale or invalid.")
+    case = next((item for item in suite["cases"] if item["id"] == request.get("caseId")), None)
+    if case is None:
+        raise ValueError(f"Request references unknown case: {request.get('caseId')}")
+    expected_case_hash = sha256_json(case)
+    if request.get("digests", {}).get("caseSha256") != expected_case_hash:
+        raise ValueError("Request case digest is stale or invalid.")
+    adapter = next((item for item in load_adapters(distribution) if item["id"] == request.get("hostId")), None)
+    if adapter is None:
+        raise ValueError(f"Request references unknown host: {request.get('hostId')}")
+    current = {
+        "skillSha256": sha256_file(distribution / "SKILL.md"),
+        "adapterSha256": sha256_file(Path(adapter["_path"])),
+        "caseSha256": expected_case_hash,
+    }
+    if request.get("digests") != current:
+        raise ValueError("Request is stale: the skill, host adapter, or corpus case has changed.")
+    execution: dict[str, Any] | None = None
+    if mode == "observed":
+        if execution_path is None or not execution_path.is_file():
+            raise ValueError("Observed evaluation requires an execution record.")
+        execution = load_json(execution_path)
+        issues = _validate_observed_execution(execution, request, request_path)
+        if issues:
+            raise ValueError(issues[0])
+    required_paths = ["source_model.json", "diagram_lock.json", "diagram_model.json"]
+    missing = [relative for relative in required_paths if not (project / relative).is_file()]
+    if missing:
+        raise ValueError(f"Project is missing required contracts: {', '.join(missing)}")
+    source = load_json(project / "source_model.json")
+    lock = load_json(project / "diagram_lock.json")
+    model = load_json(project / "diagram_model.json")
+    expected = case["expectations"]
+    dimensions = {
+        "semantics": _score(_semantic_checks(model, expected)),
+        "evidence": _score(_evidence_checks(source, model)),
+        "assets": _score(_asset_checks(project, model, expected)),
+        "routing": _score(_routing_checks(project, model, lock, expected)),
+        "gates": _score(_gate_checks(project)),
+    }
+    passed = all(dimensions[name]["score"] >= PASS_THRESHOLD for name in DIMENSIONS)
+    artifacts = {}
+    for relative in [*required_paths, "artifacts/diagram.drawio", "reports/diagram_qa.json", "reports/visual_qa.json"]:
+        path = project / relative
+        if path.is_file():
+            artifacts[relative] = sha256_file(path)
+    evaluated_at = utc_now()
+    result = {
+        "schemaVersion": "1.0",
+        "resultId": f"{request['hostId']}:{request['caseId']}:{sha256_json(artifacts)[:12]}",
+        "mode": mode,
+        "status": "fixture" if mode == "fixture" else ("verified" if passed else "failed"),
+        "hostId": request["hostId"],
+        "caseId": request["caseId"],
+        "digests": {**request["digests"], "requestSha256": sha256_file(request_path), "projectArtifactsSha256": sha256_json(artifacts)},
+        "dimensions": dimensions,
+        "passed": passed,
+        "evaluatedAt": evaluated_at,
+        "execution": execution,
+    }
+    return result
+
+
+def build_matrix(results: list[dict[str, Any]], *, detect: bool = True, root: Path | None = None) -> dict[str, Any]:
+    distribution = root or resource_root()
+    capabilities = host_capabilities(distribution)
+    suite = load_suite(distribution)
+    case_hashes = {case["id"]: sha256_json(case) for case in suite["cases"]}
+    skill_hash = sha256_file(distribution / "SKILL.md")
+    adapter_hashes = {adapter["id"]: sha256_file(Path(adapter["_path"])) for adapter in load_adapters(distribution)}
+    for index, result in enumerate(results):
+        issues = validate_result(result)
+        if issues:
+            raise ValueError(f"Invalid conformance result at index {index}: {issues[0]}")
+    rows = []
+    for host in capabilities["hosts"]:
+        current_results = [
+            result
+            for result in results
+            if result.get("hostId") == host["id"]
+            and result.get("mode") == "observed"
+            and result.get("caseId") in case_hashes
+            and result.get("digests", {}).get("skillSha256") == skill_hash
+            and result.get("digests", {}).get("adapterSha256") == adapter_hashes[host["id"]]
+            and result.get("digests", {}).get("caseSha256") == case_hashes[result["caseId"]]
+        ]
+        latest: dict[str, dict[str, Any]] = {}
+        for result in sorted(current_results, key=lambda item: str(item.get("evaluatedAt", ""))):
+            latest[str(result["caseId"])] = result
+        observed = list(latest.values())
+        verified = [result for result in observed if result.get("status") == "verified"]
+        failed = [result for result in observed if result.get("status") == "failed"]
+        if failed:
+            state = "failed"
+        elif len(verified) == len(suite["cases"]):
+            state = "verified"
+        elif detect and not host["available"]:
+            state = "unavailable"
+        else:
+            state = "not-run"
+        rows.append({**host, "state": state, "verifiedCases": sorted({item["caseId"] for item in verified}), "failedCases": sorted({item["caseId"] for item in failed})})
+    return {"schemaVersion": "1.0", "generatedAt": utc_now(), "suiteId": suite["suiteId"], "hosts": rows}
+
+
+def matrix_markdown(matrix: dict[str, Any]) -> str:
+    lines = [
+        "# Host capability and conformance matrix",
+        "",
+        f"Suite: `{matrix['suiteId']}`. A `verified` state requires observed execution evidence; fixtures never change host status.",
+        "",
+        "| Host | Local state | Execution | Discovery paths | Verified cases | Limitations |",
+        "|---|---|---|---|---|---|",
+    ]
+    for host in matrix["hosts"]:
+        paths = "<br>".join(f"`{path}`" for path in host["discoveryPaths"])
+        cases = ", ".join(host["verifiedCases"]) or "None"
+        limitations = " ".join(host["limitations"]).replace("|", "\\|")
+        lines.append(f"| {host['displayName']} | **{host['state']}** | {host['execution']} | {paths} | {cases} | {limitations} |")
+    lines.extend(["", "Local availability is diagnostic only. It is not proof that a host completed the NexCanvas workflow.", ""])
+    return "\n".join(lines)

--- a/src/nexcanvas/conformance.py
+++ b/src/nexcanvas/conformance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
@@ -330,7 +331,12 @@ def _routing_checks(project: Path, model: dict[str, Any], lock: dict[str, Any], 
 def _gate_checks(project: Path) -> list[dict[str, Any]]:
     diagram_qa = load_json(project / "reports" / "diagram_qa.json") if (project / "reports" / "diagram_qa.json").is_file() else {}
     visual_qa = load_json(project / "reports" / "visual_qa.json") if (project / "reports" / "visual_qa.json").is_file() else {}
-    postflight = run_postflight(project)
+    # Postflight may promote already embedded assets to RenderVerified. Evaluate
+    # an isolated copy so conformance never repairs or changes the host output.
+    with tempfile.TemporaryDirectory(prefix="nexcanvas-conformance-") as directory:
+        isolated = Path(directory) / "project"
+        shutil.copytree(project, isolated)
+        postflight = run_postflight(isolated)
     visual = visual_qa.get("manualReview", {})
     return [
         _check("editable-drawio", (project / "artifacts" / "diagram.drawio").is_file(), "artifacts/diagram.drawio"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ class UnifiedCliTests(unittest.TestCase):
             action for action in parser._actions if isinstance(action, argparse._SubParsersAction)
         )
         self.assertTrue(
-            {"doctor", "init", "analyze", "plan", "build", "render", "qa", "postflight", "generate", "sync", "migrate"}.issubset(
+            {"doctor", "init", "analyze", "plan", "build", "render", "qa", "postflight", "generate", "sync", "migrate", "conformance"}.issubset(
                 subparsers.choices
             )
         )

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -53,6 +53,8 @@ class ConformanceTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory)
             prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            manifest = ROOT / "examples" / "v5-multi-agent-workflow" / "assets" / "asset_manifest.json"
+            before = sha256_file(manifest)
             result = evaluate_run(
                 output / "request.json",
                 ROOT / "examples" / "v5-multi-agent-workflow",
@@ -62,6 +64,7 @@ class ConformanceTests(unittest.TestCase):
             self.assertTrue(result["passed"])
             self.assertEqual(result["status"], "fixture")
             self.assertTrue(all(result["dimensions"][name]["score"] == 1.0 for name in result["dimensions"]))
+            self.assertEqual(sha256_file(manifest), before)
 
     def test_observed_evaluation_requires_execution_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from nexcanvas.common import sha256_file
+from nexcanvas.conformance import (
+    build_matrix,
+    evaluate_run,
+    host_capabilities,
+    load_adapters,
+    load_suite,
+    matrix_markdown,
+    prepare_run,
+    validate_adapter,
+    validate_suite,
+)
+
+
+class ConformanceTests(unittest.TestCase):
+    def test_suite_covers_all_semantic_intents(self) -> None:
+        suite = load_suite(ROOT)
+        self.assertEqual(validate_suite(suite), [])
+        self.assertEqual(
+            {case["expectations"]["viewIntent"] for case in suite["cases"]},
+            {"architecture", "workflow", "sequence", "data-flow", "lifecycle"},
+        )
+
+    def test_adapters_share_one_skill_core(self) -> None:
+        adapters = load_adapters(ROOT)
+        self.assertEqual({adapter["id"] for adapter in adapters}, {"codex", "github-copilot", "claude-code", "generic-agent-skills"})
+        for adapter in adapters:
+            self.assertEqual(validate_adapter(adapter), [])
+            self.assertEqual(adapter["sharedSkill"], "SKILL.md")
+
+    def test_prepare_binds_skill_adapter_and_case_digests(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            request = json.loads((output / "request.json").read_text(encoding="utf-8"))
+            template = json.loads((output / "execution.template.json").read_text(encoding="utf-8"))
+            self.assertEqual(request["digests"]["skillSha256"], sha256_file(ROOT / "SKILL.md"))
+            self.assertEqual(template["requestSha256"], sha256_file(output / "request.json"))
+            self.assertTrue((output / "PROMPT.md").is_file())
+
+    def test_reference_project_passes_fixture_evaluation_without_verifying_host(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            result = evaluate_run(
+                output / "request.json",
+                ROOT / "examples" / "v5-multi-agent-workflow",
+                mode="fixture",
+                root=ROOT,
+            )
+            self.assertTrue(result["passed"])
+            self.assertEqual(result["status"], "fixture")
+            self.assertTrue(all(result["dimensions"][name]["score"] == 1.0 for name in result["dimensions"]))
+
+    def test_observed_evaluation_requires_execution_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            with self.assertRaisesRegex(ValueError, "execution record"):
+                evaluate_run(
+                    output / "request.json",
+                    ROOT / "examples" / "v5-multi-agent-workflow",
+                    mode="observed",
+                    root=ROOT,
+                )
+
+    def test_observed_evaluation_binds_real_evidence_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            transcript = output / "transcript.jsonl"
+            transcript.write_text('{"event":"fixture host execution"}\n', encoding="utf-8")
+            execution = json.loads((output / "execution.template.json").read_text(encoding="utf-8"))
+            execution.update(
+                {
+                    "hostVersion": "test-host 1.0",
+                    "surface": "unit-test",
+                    "startedAt": "2026-09-10T00:00:00Z",
+                    "completedAt": "2026-09-10T00:01:00Z",
+                    "invocation": "unit-test runner",
+                    "evidence": [{"path": transcript.name, "sha256": sha256_file(transcript)}],
+                }
+            )
+            execution_path = output / "execution.json"
+            execution_path.write_text(json.dumps(execution), encoding="utf-8")
+            result = evaluate_run(
+                output / "request.json",
+                ROOT / "examples" / "v5-multi-agent-workflow",
+                mode="observed",
+                execution_path=execution_path,
+                root=ROOT,
+            )
+            self.assertEqual(result["status"], "verified")
+            transcript.write_text("tampered\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "mismatched digest"):
+                evaluate_run(
+                    output / "request.json",
+                    ROOT / "examples" / "v5-multi-agent-workflow",
+                    mode="observed",
+                    execution_path=execution_path,
+                    root=ROOT,
+                )
+
+    def test_stale_skill_digest_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            request = json.loads((output / "request.json").read_text(encoding="utf-8"))
+            request["digests"]["skillSha256"] = "0" * 64
+            (output / "request.json").write_text(json.dumps(request), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "stale"):
+                evaluate_run(
+                    output / "request.json",
+                    ROOT / "examples" / "v5-multi-agent-workflow",
+                    mode="fixture",
+                    root=ROOT,
+                )
+
+    def test_fixture_never_changes_host_matrix_to_verified(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            fixture = evaluate_run(
+                output / "request.json",
+                ROOT / "examples" / "v5-multi-agent-workflow",
+                mode="fixture",
+                root=ROOT,
+            )
+            matrix = build_matrix([fixture], detect=False, root=ROOT)
+            codex = next(host for host in matrix["hosts"] if host["id"] == "codex")
+            self.assertEqual(codex["state"], "not-run")
+            self.assertIn("fixtures never change host status", matrix_markdown(matrix))
+
+    def test_one_observed_case_cannot_verify_an_entire_host(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            prepare_run("multi-agent-workflow", "codex", output, ROOT)
+            partial = evaluate_run(
+                output / "request.json",
+                ROOT / "examples" / "v5-multi-agent-workflow",
+                mode="fixture",
+                root=ROOT,
+            )
+            partial["mode"] = "observed"
+            partial["status"] = "verified"
+            partial["execution"] = {"mode": "observed"}
+            matrix = build_matrix([partial], detect=False, root=ROOT)
+            codex = next(host for host in matrix["hosts"] if host["id"] == "codex")
+            self.assertEqual(codex["state"], "not-run")
+            self.assertEqual(codex["verifiedCases"], ["multi-agent-workflow"])
+
+    def test_doctor_uses_explicit_truthful_states(self) -> None:
+        report = host_capabilities(ROOT)
+        self.assertTrue(report["hosts"])
+        self.assertTrue({host["state"] for host in report["hosts"]}.issubset({"not-run", "unavailable"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflows/conformance.md
+++ b/workflows/conformance.md
@@ -1,0 +1,55 @@
+# Cross-agent conformance workflow
+
+Use this workflow to measure whether a host executes the shared NexCanvas skill,
+not to create a normal user diagram. Read ADR 0009 and `docs/conformance.md`
+before publishing a result.
+
+## 1. Inspect the host
+
+Run `nexcanvas conformance doctor`. Availability only means that a compatible
+executable is visible locally; it does not prove conformance.
+
+## 2. Prepare an immutable run pack
+
+```bash
+nexcanvas conformance prepare <case-id> --host <host-id> --output <run-pack>
+```
+
+The pack binds the exact corpus case, adapter, and shared `SKILL.md` by SHA-256.
+Do not edit `request.json` or `PROMPT.md` after preparing it.
+
+## 3. Execute in the named host
+
+Start a fresh host session, submit `PROMPT.md`, and retain the transcript or task
+export. The host must create the complete NexCanvas project in the pack's
+`project/` directory. Do not repair another host's output before evaluation.
+
+Fill `execution.template.json`, rename it to `execution.json`, and hash the raw
+host evidence file. Record concrete `hostVersion` and `surface` values. A generic
+claim such as "Agent Skills" is insufficient.
+
+## 4. Evaluate without subjective substitutions
+
+```bash
+nexcanvas conformance evaluate <run-pack>/request.json \
+  --project <run-pack>/project \
+  --mode observed \
+  --execution <run-pack>/execution.json \
+  --output <run-pack>/result.json
+```
+
+The evaluator measures semantics, evidence, assets, routing, and completed
+delivery gates. Every dimension must pass. Use `--mode fixture` only while
+testing the evaluator; fixture output can never verify a host.
+
+## 5. Publish the truthful matrix
+
+```bash
+nexcanvas conformance report <run-pack>/result.json \
+  --output host-matrix.json \
+  --markdown host-matrix.md
+```
+
+Publish raw observed results with the matrix when privacy and licensing permit.
+Redact secrets before recording evidence, but never replace evidence with a prose
+summary. Re-run a case whenever its skill, adapter, or corpus digest changes.


### PR DESCRIPTION
## Summary
- add one shared, hash-bound cross-agent conformance core with thin data-only host adapters
- add a five-intent corpus and deterministic scoring for semantics, evidence, assets, routing, and delivery gates
- add prepare/evaluate/report CLI commands, public schemas, documentation, package smoke coverage, and a dedicated CI gate
- keep observed host status truthful: fixtures never verify a host and all five current cases are required for full verification

## Contract impact
Adds preview schema 1.0 contracts for suites, adapters, executions, and results. Existing diagram/project schemas are unchanged.

## Validation
- 84 unit tests passed
- 25 Draw.io QA regression tests passed
- conformance validation: 5 cases, 4 adapters, 2 fixture baselines
- repository and Agent Skill validators passed
- wheel/editable package smoke passed outside the repository

## Current limitation
This PR publishes the harness and a truthful not-run matrix. It does not claim Codex, Copilot, or Claude conformance without fresh observed host evidence.